### PR TITLE
fix compile error ”unknown type name ‘uint32_t’“ using gcc4.8.2

### DIFF
--- a/src/digest.c
+++ b/src/digest.c
@@ -17,6 +17,7 @@
  */
 
 #include "pmurhashAPI.h"
+#include <stdint.h>
 
 const uint32_t 
   MURMURHASH3_H_SEED = 3120602769LL,


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1319585/14880703/e1dbee60-0d62-11e6-8947-c8c402ea9cd5.png)
